### PR TITLE
feat: adjust forceUpdate to avoid why-did-you-render mistake check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,14 +92,14 @@ export default function init(initOpt: CubeState.InitOpt = {}) {
       const updaters: Array<CubeState.Updater<MergedState>> = [];
 
       function useStore<P>(selector: CubeState.StateSelector<MergedState, P>) {
-        const forceUpdate = useState({})[1];
+        const forceUpdate = useState(_state)[1];
 
         const updater: any = (
           oldState: MergedState,
           nextState: MergedState
         ) => {
           const shouldUpdate = !equal(selector(oldState), selector(nextState));
-          shouldUpdate && forceUpdate({});
+          shouldUpdate && forceUpdate(nextState);
           updater.dirty = false;
         };
         updaters.push(updater);


### PR DESCRIPTION
`@welldone-software/why-did-you-render `这个插件算是一个下载量比较大的渲染优化插件
当使用这个插件检查页面是否有无效的渲染时，它会认定所有useState的setState动作前后更新的对象deepEqual但引用不同就是无效渲染，所以forceUpdate一直使用`{}`来更新就会触发它的警告，虽然事实上并不是真的触发了无效的渲染。